### PR TITLE
Rescue exception raised by start_subsegment

### DIFF
--- a/lib/aws_ex_ray/ecto/logger.ex
+++ b/lib/aws_ex_ray/ecto/logger.ex
@@ -11,9 +11,9 @@ defmodule AwsExRay.Ecto.Logger do
       tracing_pid: entry.caller_pid
     ]
 
-    case AwsExRay.start_subsegment("Ecto", opts) do
+    case start_subsegment("Ecto", opts) do
 
-      {:error, :out_of_xray} -> :ok
+      {:error, _reason} -> :ok
 
       {:ok, subsegment} ->
 
@@ -46,6 +46,14 @@ defmodule AwsExRay.Ecto.Logger do
 
     end
 
+  end
+
+  defp start_subsegment(name, opts) do
+    try do
+      AwsExRay.start_subsegment(name, opts)
+    rescue
+      e -> {:error, e}
+    end
   end
 
 end


### PR DESCRIPTION
`AwsExRay.start_subsegment` can raise an exception if the ETS table that it uses has not been initialized. This can happen, for instance, when running migrations and the `AwsExRay.Application.init` function is not called. Rescue the exception so that `AwsExRay.Ecto.Logger` does not interfere with running Ecto migrations.